### PR TITLE
gofmt and error check rewrite

### DIFF
--- a/main.go
+++ b/main.go
@@ -2,14 +2,18 @@ package main
 
 import (
 	"fmt"
+	"io"
+	"os"
+	"path/filepath"
+	"time"
+
 	pb "github.com/cheggaaa/pb"
+	"github.com/dustin/go-humanize"
 	core "github.com/ipfs/go-ipfs/core"
 	path "github.com/ipfs/go-ipfs/path"
 	uio "github.com/ipfs/go-ipfs/unixfs/io"
 	"github.com/jawher/mow.cli"
 	context "golang.org/x/net/context"
-	"io"
-	"os"
 )
 
 func main() {
@@ -23,38 +27,42 @@ func main() {
 	outFile := cmd.StringOpt("o output", "", "output file path")
 	cmd.Action = func() {
 		if *outFile == "" {
-			*outFile = "./" + *hash
+			*outFile = filepath.Base(*hash)
 		}
 
-		get(*hash, *outFile)
+		if err := get(*hash, *outFile); err != nil {
+			fmt.Printf("ipget failed: %s", err)
+			os.Remove(*outFile)
+			os.Exit(1)
+		}
 	}
 	cmd.Run(os.Args)
 }
 
-func get(path, outFile string) {
+func get(path, outFile string) error {
+	start := time.Now()
 	node, err := core.NewNode(context.Background(), &core.BuildCfg{
 		Online: true,
 	})
 	if err != nil {
-		panic(err)
+		return fmt.Errorf("ipfs NewNode() failed: %s", err)
 	}
 
 	err = node.Bootstrap(core.DefaultBootstrapConfig)
 	if err != nil {
-		fmt.Printf("%v\n", err)
-		return
+		return fmt.Errorf("node Bootstrap failed: %s", err)
 	}
+
+	fmt.Println("IPFS Node bootstraped (took %v)", time.Since(start))
 
 	reader, length, err := cat(node.Context(), node, path)
 	if err != nil {
-		fmt.Printf("%v\n", err)
-		return
+		return fmt.Errorf("cat failed: %s", err)
 	}
 
 	file, err := os.Create(outFile)
 	if err != nil {
-		fmt.Printf("%v", err)
-		return
+		return fmt.Errorf("creating output file %q failed: %s", outFile, err)
 	}
 
 	bar := pb.New(int(length)).SetUnits(pb.U_BYTES)
@@ -62,11 +70,14 @@ func get(path, outFile string) {
 	bar.Start()
 	writer := io.MultiWriter(file, bar)
 
-	io.Copy(writer, reader)
+	if _, err := io.Copy(writer, reader); err != nil {
+		return fmt.Errorf("copying failed: %s", err)
+	}
 
 	bar.Finish()
 
-	fmt.Printf("wrote %v to %v (%v bytes)\n", path, outFile, length)
+	fmt.Printf("wrote %q to %q (%s) (took %v)\n", path, outFile, humanize.Bytes(length), time.Since(start))
+	return nil
 }
 
 func cat(ctx context.Context, node *core.IpfsNode, fpath string) (io.Reader, uint64, error) {
@@ -79,7 +90,6 @@ func cat(ctx context.Context, node *core.IpfsNode, fpath string) (io.Reader, uin
 	if err != nil {
 		return nil, 0, err
 	}
-	length := uint64(reader.Size())
 
-	return reader, length, nil
+	return reader, reader.Size(), nil
 }


### PR DESCRIPTION
Hey, thanks for starting this! The only fault I found was the missing error check on `io.Copy()`, which could indicate disk full or a crash on the reader/ipfs node side. I also took the liberty of humanizing the byte count in the final print and fixed #1  by using `filepath.Base()` on the path argument. And you should use gofmt to format your code. ;)